### PR TITLE
Extension Doesn't Work If Title Is "Directory listing for /"

### DIFF
--- a/source/40-utils.js
+++ b/source/40-utils.js
@@ -1,6 +1,6 @@
 var parser = {
   is_directory_listing: function (content) {
-    return content.search("<title>Index of /") !== -1 && content.search("<h1>Index of /") !== -1;
+    return content.search("<title>Index of /") !== -1 && content.search("<h1>Index of /") !== -1 || content.search("<title>Directory listing for /") !== -1 && content.search("<h1>Directory listing for /") !== -1;
   },
   sort_rows: function (rows) {
     return rows.sort(function (a, b) {


### PR DESCRIPTION
Fixed It By Adding A Condition In source/40-utils.js